### PR TITLE
LOSSLESS-378-350: Second Reported Account bugs

### DIFF
--- a/contracts/LosslessV3/LosslessReporting.sol
+++ b/contracts/LosslessV3/LosslessReporting.sol
@@ -55,6 +55,7 @@ contract LosslessReporting is Initializable, ContextUpgradeable, PausableUpgrade
 
     mapping(uint256 => address) public reporter;
     mapping(uint256 => address) public reportedAddress;
+    mapping(uint256 => address) public secondReportedAddress;
     mapping(uint256 => uint256) public reportTimestamps;
     mapping(uint256 => address) public reportTokens;
     mapping(uint256 => bool) public secondReports;
@@ -248,7 +249,7 @@ contract LosslessReporting is Initializable, ContextUpgradeable, PausableUpgrade
         amountReported[reportId] += losslessToken.balanceOf(account);
 
         losslessController.addToBlacklist(account);
-        reportedAddress[reportId] = account;
+        secondReportedAddress[reportId] = account;
 
         emit SecondReportsubmitted(token, account, reportId);
     }

--- a/test/V3 Tests/LosslessGovernance.js
+++ b/test/V3 Tests/LosslessGovernance.js
@@ -9,7 +9,7 @@ const { setupAddresses, setupEnvironment, setupToken } = require('./utilsV3');
 let adr;
 let env;
 
-describe.only('Lossless Governance', () => {
+describe('Lossless Governance', () => {
   beforeEach(async () => {
     adr = await setupAddresses();
     env = await setupEnvironment(adr.lssAdmin,


### PR DESCRIPTION
Fixed main reported account being overwritten in secondReport
Saved secondReport address separately
Added compensation to the secondary reported address when wrongly reported