### PR TITLE
Various changes on Lossless Staking

### DIFF
--- a/contracts/LosslessV3/LosslessStaking.sol
+++ b/contracts/LosslessV3/LosslessStaking.sol
@@ -39,7 +39,6 @@ interface ILssController {
     function setReporterPayoutStatus(address _reporter, bool status, uint256 reportId) external; 
     function admin() external view returns (address);
     function pauseAdmin() external view returns (address);
-    function recoveryAdmin() external view returns (address);
     function getCompensationPercentage() external view returns (uint256);
 }
 
@@ -51,8 +50,6 @@ interface ILssGovernance {
 /// @title Lossless Staking Contract
 /// @notice The Staking contract is in charge of handling the staking done on reports
 contract LosslessStaking is Initializable, ContextUpgradeable, PausableUpgradeable {
-
-    uint256 public cooldownPeriod;
 
     struct Stake {
         mapping(uint256 => StakeInfo) stakeInfoOnReport;
@@ -69,8 +66,6 @@ contract LosslessStaking is Initializable, ContextUpgradeable, PausableUpgradeab
     ILssReporting public losslessReporting;
     ILssController public losslessController;
     ILssGovernance public losslessGovernance;
-
-    mapping(address => bool) whitelist;
     
     mapping(address => Stake) private stakes;
     mapping(uint256 => address[]) public stakers;
@@ -80,17 +75,11 @@ contract LosslessStaking is Initializable, ContextUpgradeable, PausableUpgradeab
     event Staked(address indexed token, address indexed account, uint256 reportId);
 
     function initialize(address _losslessReporting, address _losslessController) public initializer {
-       cooldownPeriod = 5 minutes;
        losslessReporting = ILssReporting(_losslessReporting);
        losslessController = ILssController(_losslessController);
     }
 
     // --- MODIFIERS ---
-
-    modifier onlyLosslessRecoveryAdmin() {
-        require(msg.sender == losslessController.recoveryAdmin(), "LSS: Must be recoveryAdmin");
-        _;
-    }
 
     modifier onlyLosslessAdmin() {
         require(losslessController.admin() == msg.sender, "LSS: Must be admin");
@@ -222,7 +211,7 @@ contract LosslessStaking is Initializable, ContextUpgradeable, PausableUpgradeab
         require(reportId > 0 && (reportTimestamp + losslessController.getReportLifetime()) > block.timestamp, "LSS: report does not exists");
 
         uint256 stakeAmount = losslessController.getStakeAmount();
-        require(losslessToken.balanceOf(msg.sender) >= stakeAmount, "LSS: Not enough $LSS to stake");
+        //require(losslessToken.balanceOf(msg.sender) >= stakeAmount, "LSS: Not enough $LSS to stake");
 
         uint256 stakerCoefficient;
         stakerCoefficient = calculateCoefficient(reportTimestamp);

--- a/test/V3 Tests/LosslessStaking.js
+++ b/test/V3 Tests/LosslessStaking.js
@@ -159,7 +159,7 @@ describe('Lossless Staking', () => {
 
         await expect(
           env.lssStaking.connect(adr.staker5).stake(1),
-        ).to.be.revertedWith('LSS: Not enough $LSS to stake');
+        ).to.be.revertedWith('LSS: Insufficient balance');
       });
     });
 


### PR DESCRIPTION
LOSSLESS-397: Remove cooldownPeriod in LosslessStaking
LOSSLESS-398: Remove whitelist from LosslessStaking
LOSSLESS-400: Remove onlyLosslessRecoveryAdmin in LosslessStaking
LOSSLESS-402: Remove losslessToken.balanceOf(msg.sender) >= stakeAmount in LosslessStaking

