### PR TITLE
LOSSLESS-875: Remove require(!blacklist[recipient], "LSS: Recipient is blacklisted");

### DIFF
--- a/contracts/LosslessControllerV3.sol
+++ b/contracts/LosslessControllerV3.sol
@@ -513,7 +513,6 @@ contract LosslessControllerV3 is Initializable, ContextUpgradeable, PausableUpgr
         }
 
         require(!blacklist[sender], "LSS: You cannot operate");
-        require(!blacklist[recipient], "LSS: Recipient is blacklisted");
         
         if (tokenLockTimeframe[msg.sender] != 0) {
             _evaluateTransfer(sender, recipient, amount);
@@ -528,7 +527,6 @@ contract LosslessControllerV3 is Initializable, ContextUpgradeable, PausableUpgr
         }
 
         require(!blacklist[msgSender], "LSS: You cannot operate");
-        require(!blacklist[recipient], "LSS: Recipient is blacklisted");
         require(!blacklist[sender], "LSS: Sender is blacklisted");
 
         if (tokenLockTimeframe[msg.sender] != 0) {

--- a/test/domain based tests/report.js
+++ b/test/domain based tests/report.js
@@ -125,22 +125,6 @@ describe(scriptName, () => {
         ).to.be.revertedWith('LSS: You cannot operate');
       });
 
-      it('should prevent blacklisted account to receive tokens', async () => {
-        await lerc20Token.connect(adr.lerc20InitialHolder)
-          .transfer(adr.maliciousActor1.address, 200);
-
-        await ethers.provider.send('evm_increaseTime', [
-          Number(time.duration.minutes(5)),
-        ]);
-
-        await env.lssReporting.connect(adr.reporter1)
-          .report(lerc20Token.address, adr.maliciousActor1.address);
-
-        await expect(
-          lerc20Token.connect(adr.lerc20InitialHolder).transfer(adr.maliciousActor1.address, 10),
-        ).to.be.revertedWith('LSS: Recipient is blacklisted');
-      });
-
       it('should prevent blacklisted account to transferFrom tokens', async () => {
         await lerc20Token.connect(adr.lerc20InitialHolder)
           .transfer(adr.maliciousActor1.address, 200);
@@ -175,28 +159,6 @@ describe(scriptName, () => {
         await expect(
           lerc20Token.connect(adr.maliciousActor1).transferFrom(adr.maliciousActor2.address, adr.maliciousActor3.address, 10),
         ).to.be.revertedWith('LSS: You cannot operate');
-      });
-
-      it('should prevent blacklisted account to receive tokens using transferFrom', async () => {
-        await lerc20Token.connect(adr.lerc20InitialHolder)
-          .transfer(adr.maliciousActor1.address, 200);
-
-        await lerc20Token.connect(adr.lerc20InitialHolder)
-          .transfer(adr.maliciousActor3.address, 100);
-
-        await lerc20Token.connect(adr.maliciousActor1).approve(adr.maliciousActor2.address, 200);
-        await lerc20Token.connect(adr.maliciousActor3).approve(adr.maliciousActor2.address, 200);
-
-        await ethers.provider.send('evm_increaseTime', [
-          Number(time.duration.minutes(5)),
-        ]);
-
-        await env.lssReporting.connect(adr.reporter1)
-          .report(lerc20Token.address, adr.maliciousActor1.address);
-
-        await expect(
-          lerc20Token.connect(adr.maliciousActor2).transferFrom(adr.maliciousActor3.address, adr.maliciousActor1.address, 10),
-        ).to.be.revertedWith('LSS: Recipient is blacklisted');
       });
     });
 


### PR DESCRIPTION
Removed require that prevents blacklisted account to receive tokens.